### PR TITLE
Ordering API: Add missing properties

### DIFF
--- a/lib/amazon_business_api/acceptance_artifact/deserializer.rb
+++ b/lib/amazon_business_api/acceptance_artifact/deserializer.rb
@@ -8,6 +8,8 @@ module AmazonBusinessApi
   class AcceptanceArtifact
     class Deserializer < AmazonBusinessApi::Deserializer
       attribute :acceptance_artifact_type, hash_attribute: :acceptanceArtifactType
+
+      # Attributes below are all possible attributes of an AcceptanceArtifact
       attribute :identifier, hash_attribute: :identifier
       attribute :lower_boundary, hash_attribute: :lowerBoundary
       attribute :upper_boundary, hash_attribute: :upperBoundary

--- a/lib/amazon_business_api/acceptance_artifact/deserializer.rb
+++ b/lib/amazon_business_api/acceptance_artifact/deserializer.rb
@@ -1,11 +1,22 @@
 # frozen_string_literal: true
 
 require_relative '../money/deserializer'
+require_relative '../package/deserializer'
+require_relative '../package_reference/deserializer'
 
 module AmazonBusinessApi
   class AcceptanceArtifact
     class Deserializer < AmazonBusinessApi::Deserializer
       attribute :acceptance_artifact_type, hash_attribute: :acceptanceArtifactType
+      attribute :identifier, hash_attribute: :identifier
+      attribute :lower_boundary, hash_attribute: :lowerBoundary
+      attribute :upper_boundary, hash_attribute: :upperBoundary
+      references_one :amount, deserializer: Money::Deserializer,  hash_attribute: :amount
+      attribute :category, hash_attribute: :category
+      attribute :type, hash_attribute: :type
+      references_many :packages, deserializer: Package::Deserializer,  hash_attribute: :packages
+      references_many :package_references, deserializer: PackageReference::Deserializer,  hash_attribute: :package_references
+      attribute :quantity, hash_attribute: :quantity
     end
   end
 end

--- a/lib/amazon_business_api/acceptance_artifact/deserializer.rb
+++ b/lib/amazon_business_api/acceptance_artifact/deserializer.rb
@@ -13,11 +13,13 @@ module AmazonBusinessApi
       attribute :identifier, hash_attribute: :identifier
       attribute :lower_boundary, hash_attribute: :lowerBoundary
       attribute :upper_boundary, hash_attribute: :upperBoundary
-      references_one :amount, deserializer: Money::Deserializer,  hash_attribute: :amount
+      references_one :amount, deserializer: Money::Deserializer, hash_attribute: :amount
       attribute :category, hash_attribute: :category
       attribute :type, hash_attribute: :type
-      references_many :packages, deserializer: Package::Deserializer,  hash_attribute: :packages
-      references_many :package_references, deserializer: PackageReference::Deserializer,  hash_attribute: :package_references
+      # references_many :packages, deserializer: Package::Deserializer,
+      #                 hash_attribute: :packages
+      # references_many :package_references, deserializer: PackageReference::Deserializer,
+      #                 hash_attribute: :package_references
       attribute :quantity, hash_attribute: :quantity
     end
   end

--- a/lib/amazon_business_api/package/deserializer.rb
+++ b/lib/amazon_business_api/package/deserializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative '../package_reference/deserializer'
+require_relative '../package_attribute/deserializer'
+
+module AmazonBusinessApi
+  class Package
+    class Deserializer < AmazonBusinessApi::Deserializer
+      references_one :package_reference, deserializer: PackageReference::Deserializer, hash_attribute: :packageReference
+      references_many :package_attributes, deserializer: PackageAttribute::Deserializer, hash_attribute: :packageAttributes
+    end
+  end
+end

--- a/lib/amazon_business_api/package_attribute/deserializer.rb
+++ b/lib/amazon_business_api/package_attribute/deserializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module AmazonBusinessApi
+  class PackageAttribute
+    class Deserializer < AmazonBusinessApi::Deserializer
+      attribute :package_attribute_type, hash_attribute: :packageAttributeType
+    end
+  end
+end

--- a/lib/amazon_business_api/package_reference/deserializer.rb
+++ b/lib/amazon_business_api/package_reference/deserializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module AmazonBusinessApi
+  class PackageReference
+    class Deserializer < AmazonBusinessApi::Deserializer
+      attribute :package_reference_type, hash_attribute: :packageReferenceType
+    end
+  end
+end

--- a/lib/amazon_business_api/rejection_artifact/deserializer.rb
+++ b/lib/amazon_business_api/rejection_artifact/deserializer.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 
+require_relative '../money/deserializer'
+
 module AmazonBusinessApi
   class RejectionArtifact
     class Deserializer < AmazonBusinessApi::Deserializer
       attribute :rejection_artifact_type, hash_attribute: :rejectionArtifactType
+      attribute :quantity, hash_attribute: :quantity
+      attribute :message, hash_attribute: :message
+      attribute :code, hash_attribute: :code
+      attribute :minimum_age, hash_attribute: :minimumAge
+      attribute :upper_boundary, hash_attribute: :upperBoundary
+      attribute :actual_date_time, hash_attribute: :actualDateTime
+      references_one :boundary, deserializer: Money::Deserializer,  hash_attribute: :boundary
+      references_one :actual_amount, deserializer: Money::Deserializer,  hash_attribute: :actualAmount
     end
   end
 end

--- a/lib/amazon_business_api/rejection_artifact/deserializer.rb
+++ b/lib/amazon_business_api/rejection_artifact/deserializer.rb
@@ -6,6 +6,8 @@ module AmazonBusinessApi
   class RejectionArtifact
     class Deserializer < AmazonBusinessApi::Deserializer
       attribute :rejection_artifact_type, hash_attribute: :rejectionArtifactType
+
+      # Attributes below are all possible attributes of a RejectionArtifact
       attribute :quantity, hash_attribute: :quantity
       attribute :message, hash_attribute: :message
       attribute :code, hash_attribute: :code

--- a/lib/amazon_business_api/resources/acceptance_artifact.rb
+++ b/lib/amazon_business_api/resources/acceptance_artifact.rb
@@ -8,6 +8,8 @@ module AmazonBusinessApi
   class AcceptanceArtifact < AmazonBusinessApi::Resource
     # https://developer-docs.amazon.com/amazon-business/docs/ordering-api-v1-reference
     attribute :acceptance_artifact_type, type: LedgerSync::Type::String
+
+    # Attributes below are all possible attributes of an AcceptanceArtifact
     attribute :identifier, type: LedgerSync::Type::String
     attribute :lower_boundary, type: LedgerSync::Type::String
     attribute :upper_boundary, type: LedgerSync::Type::String

--- a/lib/amazon_business_api/resources/acceptance_artifact.rb
+++ b/lib/amazon_business_api/resources/acceptance_artifact.rb
@@ -16,8 +16,8 @@ module AmazonBusinessApi
     references_one :amount, to: Money
     attribute :category, type: LedgerSync::Type::String
     attribute :type, type: LedgerSync::Type::String
-    references_many :packages, to: Package
-    references_many :package_references, to: PackageReference
+    # references_many :packages, to: Package
+    # references_many :package_references, to: PackageReference
     attribute :quantity, type: LedgerSync::Type::Integer
   end
 end

--- a/lib/amazon_business_api/resources/acceptance_artifact.rb
+++ b/lib/amazon_business_api/resources/acceptance_artifact.rb
@@ -1,8 +1,21 @@
 # frozen_string_literal: true
 
+require_relative 'money'
+require_relative 'package'
+require_relative 'package_reference'
+
 module AmazonBusinessApi
   class AcceptanceArtifact < AmazonBusinessApi::Resource
     # https://developer-docs.amazon.com/amazon-business/docs/ordering-api-v1-reference
     attribute :acceptance_artifact_type, type: LedgerSync::Type::String
+    attribute :identifier, type: LedgerSync::Type::String
+    attribute :lower_boundary, type: LedgerSync::Type::String
+    attribute :upper_boundary, type: LedgerSync::Type::String
+    references_one :amount, to: Money
+    attribute :category, type: LedgerSync::Type::String
+    attribute :type, type: LedgerSync::Type::String
+    references_many :packages, to: Package
+    references_many :package_references, to: PackageReference
+    attribute :quantity, type: LedgerSync::Type::Integer
   end
 end

--- a/lib/amazon_business_api/resources/package.rb
+++ b/lib/amazon_business_api/resources/package.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative 'package_reference'
+require_relative 'package_attribute'
+
+module AmazonBusinessApi
+  class Package < AmazonBusinessApi::Resource
+    # https://developer-docs.amazon.com/amazon-business/docs/ordering-api-v1-reference
+    references_one :package_reference, to: PackageReference
+    references_many :package_attributes, to: PackageAttribute
+  end
+end

--- a/lib/amazon_business_api/resources/package_attribute.rb
+++ b/lib/amazon_business_api/resources/package_attribute.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module AmazonBusinessApi
+  class PackageAttribute < AmazonBusinessApi::Resource
+    # https://developer-docs.amazon.com/amazon-business/docs/ordering-api-v1-reference
+    attribute :package_attribute_type, type: LedgerSync::Type::String
+  end
+end

--- a/lib/amazon_business_api/resources/package_reference.rb
+++ b/lib/amazon_business_api/resources/package_reference.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module AmazonBusinessApi
+  class PackageReference < AmazonBusinessApi::Resource
+    # https://developer-docs.amazon.com/amazon-business/docs/ordering-api-v1-reference
+    attribute :package_reference_type, type: LedgerSync::Type::String
+  end
+end

--- a/lib/amazon_business_api/resources/rejection_artifact.rb
+++ b/lib/amazon_business_api/resources/rejection_artifact.rb
@@ -6,6 +6,8 @@ module AmazonBusinessApi
   class RejectionArtifact < AmazonBusinessApi::Resource
     # https://developer-docs.amazon.com/amazon-business/docs/ordering-api-v1-reference
     attribute :rejection_artifact_type, type: LedgerSync::Type::String
+
+    # Attributes below are all possible attributes of a RejectionArtifact
     attribute :quantity, type: LedgerSync::Type::Integer
     attribute :message, type: LedgerSync::Type::String
     attribute :code, type: LedgerSync::Type::String

--- a/lib/amazon_business_api/resources/rejection_artifact.rb
+++ b/lib/amazon_business_api/resources/rejection_artifact.rb
@@ -1,8 +1,18 @@
 # frozen_string_literal: true
 
+require_relative 'money'
+
 module AmazonBusinessApi
   class RejectionArtifact < AmazonBusinessApi::Resource
     # https://developer-docs.amazon.com/amazon-business/docs/ordering-api-v1-reference
     attribute :rejection_artifact_type, type: LedgerSync::Type::String
+    attribute :quantity, type: LedgerSync::Type::Integer
+    attribute :message, type: LedgerSync::Type::String
+    attribute :code, type: LedgerSync::Type::String
+    attribute :minimum_age, type: LedgerSync::Type::Integer
+    attribute :upper_boundary, type: LedgerSync::Type::String
+    attribute :actual_date_time, type: LedgerSync::Type::String
+    references_one :boundary, to: Money
+    references_one :actual_amount, to: Money
   end
 end


### PR DESCRIPTION
@KostasKostogloy WIP because `references_many` raises an error when we don't receive them in the API's response.

We can rescue `attribute` but I don't think we can rescue `references_many`. Jozef told me that it's a known issue and that I can timebox myself to fix it in the LS gem directly.

**EDIT: Fix waiting to be reviewed: https://github.com/LedgerSync/ledger_sync/pull/322**

Beside that, everything's present in this PR ! You can still review it :)

### **EDIT 2: Commented the problematic lines, we can ship it.**