### PR TITLE
Add Badge and BadgeFragment resources to handle Amazon API badges res…

### DIFF
--- a/lib/amazon_business_api/badge/deserializer.rb
+++ b/lib/amazon_business_api/badge/deserializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative '../badge_fragment/deserializer'
+
+module AmazonBusinessApi
+  class Badge
+    class Deserializer < AmazonBusinessApi::Deserializer
+      references_one :fragment, deserializer: BadgeFragment::Deserializer
+    end
+  end
+end

--- a/lib/amazon_business_api/badge_fragment/deserializer.rb
+++ b/lib/amazon_business_api/badge_fragment/deserializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module AmazonBusinessApi
+  class BadgeFragment
+    class Deserializer < AmazonBusinessApi::Deserializer
+      attribute :title
+      attribute :message
+      attribute :link
+      attribute :type
+      attribute :fragments
+    end
+  end
+end

--- a/lib/amazon_business_api/offer/deserializer.rb
+++ b/lib/amazon_business_api/offer/deserializer.rb
@@ -7,6 +7,7 @@ require_relative '../quantity_price_tier/deserializer'
 require_relative '../price/deserializer'
 require_relative '../buying_restriction/deserializer'
 require_relative '../tax_exclusive_price/deserializer'
+require_relative '../badge/deserializer'
 
 module AmazonBusinessApi
   class Offer
@@ -26,7 +27,7 @@ module AmazonBusinessApi
       references_one :quantity_limits, deserializer: QuantityLimits::Deserializer, hash_attribute: :quantityLimits
       references_many :quantity_price_tiers, deserializer: QuantityPriceTier::Deserializer, hash_attribute: 'quantityPrice.quantityPriceTiers'
       references_one :tax_exclusive_price, deserializer: TaxExclusivePrice::Deserializer, hash_attribute: :taxExclusivePrice
-      attribute :badges
+      references_many :badges, deserializer: Badge::Deserializer
       references_many :buying_restrictions, deserializer: BuyingRestriction::Deserializer, hash_attribute: :buyingRestrictions
     end
   end

--- a/lib/amazon_business_api/resources/badge.rb
+++ b/lib/amazon_business_api/resources/badge.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative 'badge_fragment'
+
+module AmazonBusinessApi
+  class Badge < AmazonBusinessApi::Resource
+    references_one :fragment, to: BadgeFragment
+  end
+end

--- a/lib/amazon_business_api/resources/badge_fragment.rb
+++ b/lib/amazon_business_api/resources/badge_fragment.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative '../types/array'
+
+module AmazonBusinessApi
+  class BadgeFragment < AmazonBusinessApi::Resource
+    attribute :title, type: LedgerSync::Type::String
+    attribute :message, type: LedgerSync::Type::String
+    attribute :link, type: LedgerSync::Type::String
+    attribute :type, type: LedgerSync::Type::String
+    attribute :fragments, type: AmazonBusinessApi::Type::Array
+  end
+end

--- a/lib/amazon_business_api/resources/offer.rb
+++ b/lib/amazon_business_api/resources/offer.rb
@@ -8,6 +8,7 @@ require_relative 'quantity_limits'
 require_relative 'quantity_price_tier'
 require_relative 'buying_restriction'
 require_relative 'tax_exclusive_price'
+require_relative 'badge'
 require_relative '../types/array'
 
 module AmazonBusinessApi
@@ -28,7 +29,7 @@ module AmazonBusinessApi
     references_one :quantity_limits, to: QuantityLimits
     references_many :quantity_price_tiers, to: QuantityPriceTier
     references_one :tax_exclusive_price, to: TaxExclusivePrice
-    references_many :badges, to: Type::Array
+    references_many :badges, to: Badge
     references_many :buying_restrictions, to: BuyingRestriction
   end
 end


### PR DESCRIPTION
Problem

  The gem was failing with the error:
  Attribute badges for AmazonBusinessApi::Offer should be an array of AmazonBusinessApi::Type::Array.
  Given array containing: Hash

  This occurred when Amazon API returned badges in product offers. The badges attribute was defined as a simple array type,
   but Amazon returns a complex nested structure with badge fragments.

  Root Cause

  The badges field in Offer was defined as:
  attribute :badges, type: AmazonBusinessApi::Type::Array

  However, Amazon API returns badges as an array of complex objects:
  "badges": [
    {
      "fragment": {
        "title": "Amazon Prime",
        "message": null,
        "link": null,
        "type": "PRIME_BADGE",
        "fragments": null
      }
    }
  ]

  The deserializer couldn't properly handle this nested structure without dedicated resource classes.

  Solution

  Created proper resource classes and deserializers to handle the badge structure:

  1. BadgeFragment - Represents the fragment object containing badge details
  2. Badge - Represents the badge container that references a fragment
  3. Updated Offer to properly reference badges as a collection

How to test:
```

  def get_access_token(token)
    puts "Getting access token..."
    nil
  end

  def save_access_token(*args)
    puts "Saving access token"
    args.first
  end

  def trace_response(response)
    puts "Response traced"
    response
  end

  client = AmazonBusinessApi::Client.new(
    region: 'us',
    refresh_token: '...',
    client_id: '...',
    client_secret: '...',
    email: '...',
    get_access_token: method(:get_access_token),
    save_access_token: method(:save_access_token),
    trace_response: method(:trace_response)
  )

resource = AmazonBusinessApi::SearchProductsByAsins.new(
  product_ids: ['B08B4L8LLN'] , shipping_postal_code: '19720', facets: ['OFFERS']
)

operation = AmazonBusinessApi::SearchProductsByAsins::Operations::Search.new(
  client:, resource:
)

operation.perform
```