### PR TITLE
feat: add getShipmentReports (Reporting API v2025-06-09)

### DIFF
--- a/lib/amazon_business_api/order_metadata/deserializer.rb
+++ b/lib/amazon_business_api/order_metadata/deserializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module AmazonBusinessApi
+  class OrderMetadata
+    class Deserializer < AmazonBusinessApi::Deserializer
+      attribute :order_date, hash_attribute: :orderDate
+      attribute :order_id, hash_attribute: :orderId
+      attribute :region, hash_attribute: :region
+    end
+  end
+end

--- a/lib/amazon_business_api/resources/order_metadata.rb
+++ b/lib/amazon_business_api/resources/order_metadata.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module AmazonBusinessApi
+  class OrderMetadata < AmazonBusinessApi::Resource
+    # https://docs.business.amazon.com/docs/reporting-api-v2025-06-09-reference
+    # Nested under each shipmentsReport[] entry as `orderMetadata`.
+    attribute :order_date, type: LedgerSync::Type::String
+    attribute :order_id, type: LedgerSync::Type::String
+    attribute :region, type: LedgerSync::Type::String
+  end
+end

--- a/lib/amazon_business_api/resources/shipment_delivery_info.rb
+++ b/lib/amazon_business_api/resources/shipment_delivery_info.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module AmazonBusinessApi
+  class ShipmentDeliveryInfo < AmazonBusinessApi::Resource
+    # https://docs.business.amazon.com/docs/reporting-api-v2025-06-09-reference
+    # Nested under each shipmentsReport[] entry as `deliveryInfo`.
+    # NOTE: distinct from DeliveryInformation (Reporting API v1) — this one
+    # uses `status` rather than `deliveryStatus`.
+    attribute :expected_delivery_date, type: LedgerSync::Type::String
+    attribute :status, type: LedgerSync::Type::String
+  end
+end

--- a/lib/amazon_business_api/resources/shipment_metadata.rb
+++ b/lib/amazon_business_api/resources/shipment_metadata.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module AmazonBusinessApi
+  class ShipmentMetadata < AmazonBusinessApi::Resource
+    # https://docs.business.amazon.com/docs/reporting-api-v2025-06-09-reference
+    # Nested under each shipmentsReport[] entry as `shipmentMetadata`.
+    attribute :shipment_id, type: LedgerSync::Type::String
+    attribute :shipment_date, type: LedgerSync::Type::String
+  end
+end

--- a/lib/amazon_business_api/resources/shipment_report.rb
+++ b/lib/amazon_business_api/resources/shipment_report.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative 'shipment_report_item'
+
+module AmazonBusinessApi
+  class ShipmentReport < AmazonBusinessApi::Resource
+    # https://docs.business.amazon.com/docs/reporting-api-v2025-06-09-reference
+    # getShipmentReports — request params double as the resource attributes
+    # (mirrors the Reconciliation pattern), and the response collection is
+    # deserialized into `shipments_report`.
+    attribute :order_start_date, type: LedgerSync::Type::String
+    attribute :order_end_date, type: LedgerSync::Type::String
+    # Single order id, or comma-separated ids (max 30). NOTE: batching multiple
+    # ids in one call is unverified — current consumer queries one order.
+    attribute :order_ids, type: LedgerSync::Type::String
+    attribute :region, type: LedgerSync::Type::String
+    attribute :shipment_statuses, type: LedgerSync::Type::String
+    attribute :next_page_token, type: LedgerSync::Type::String
+    attribute :size, type: LedgerSync::Type::Integer
+
+    references_many :shipments_report, to: ShipmentReportItem
+  end
+end

--- a/lib/amazon_business_api/resources/shipment_report_item.rb
+++ b/lib/amazon_business_api/resources/shipment_report_item.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative 'order_metadata'
+require_relative 'shipment_metadata'
+require_relative 'shipment_delivery_info'
+require_relative 'address'
+
+module AmazonBusinessApi
+  class ShipmentReportItem < AmazonBusinessApi::Resource
+    # https://docs.business.amazon.com/docs/reporting-api-v2025-06-09-reference
+    # A single entry of the getShipmentReports `shipmentsReport[]` array.
+    references_one :order_metadata, to: OrderMetadata
+    references_one :shipment_metadata, to: ShipmentMetadata
+    references_one :delivery_info, to: ShipmentDeliveryInfo
+    # NOTE: uses Address (snake_case attrs) rather than PhysicalAddress, whose
+    # resource attributes are camelCase and don't match its snake_case
+    # deserializer (pre-existing bug in that class).
+    references_one :shipping_address, to: Address
+    attribute :purchase_order_number, type: LedgerSync::Type::String
+    attribute :shipment_status, type: LedgerSync::Type::String
+    # NOTE: `charges[]` is also present in the payload but omitted here — not
+    # needed by current consumers (each charge is { type, amount }).
+  end
+end

--- a/lib/amazon_business_api/shipment_delivery_info/deserializer.rb
+++ b/lib/amazon_business_api/shipment_delivery_info/deserializer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module AmazonBusinessApi
+  class ShipmentDeliveryInfo
+    class Deserializer < AmazonBusinessApi::Deserializer
+      attribute :expected_delivery_date, hash_attribute: :expectedDeliveryDate
+      attribute :status, hash_attribute: :status
+    end
+  end
+end

--- a/lib/amazon_business_api/shipment_metadata/deserializer.rb
+++ b/lib/amazon_business_api/shipment_metadata/deserializer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module AmazonBusinessApi
+  class ShipmentMetadata
+    class Deserializer < AmazonBusinessApi::Deserializer
+      attribute :shipment_id, hash_attribute: :shipmentId
+      attribute :shipment_date, hash_attribute: :shipmentDate
+    end
+  end
+end

--- a/lib/amazon_business_api/shipment_report/deserializer.rb
+++ b/lib/amazon_business_api/shipment_report/deserializer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative '../shipment_report_item/deserializer'
+
+module AmazonBusinessApi
+  class ShipmentReport
+    class Deserializer < AmazonBusinessApi::Deserializer
+      references_many :shipments_report, deserializer: ShipmentReportItem::Deserializer,
+                                         hash_attribute: :shipmentsReport
+      attribute :next_page_token, hash_attribute: :nextPageToken
+      attribute :size, hash_attribute: :size
+    end
+  end
+end

--- a/lib/amazon_business_api/shipment_report/operations/search.rb
+++ b/lib/amazon_business_api/shipment_report/operations/search.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'cgi'
+require 'date'
 
 module AmazonBusinessApi
   class ShipmentReport
@@ -10,6 +11,9 @@ module AmazonBusinessApi
       # range. orderStartDate/orderEndDate are required; the end date cannot be
       # in the future and the range cannot exceed 366 days.
       class Search < AmazonBusinessApi::Operation::Search
+        # Amazon rejects ranges wider than this (and future end dates).
+        MAX_RANGE_DAYS = 366
+
         # Resource attribute => query parameter name.
         QUERY_PARAMS = {
           order_start_date: 'orderStartDate',
@@ -28,6 +32,41 @@ module AmazonBusinessApi
             optional(:region).maybe(:string)
             optional(:shipment_statuses).maybe(:string)
             optional(:next_page_token).maybe(:string)
+          end
+
+          # Reject invalid date formats client-side before hitting the API.
+          rule(:order_start_date) do
+            key.failure('must be a valid date') if parse_date(value).nil?
+          end
+
+          # End date must parse and cannot be in the future.
+          rule(:order_end_date) do
+            parsed = parse_date(value)
+            if parsed.nil?
+              key.failure('must be a valid date')
+            elsif parsed > Date.today
+              key.failure('cannot be in the future')
+            end
+          end
+
+          # Inclusive range cannot exceed 366 days.
+          rule(:order_start_date, :order_end_date) do
+            start_date = parse_date(values[:order_start_date])
+            end_date = parse_date(values[:order_end_date])
+            next unless start_date && end_date
+
+            inclusive_days = (end_date - start_date).to_i + 1
+            if inclusive_days > MAX_RANGE_DAYS
+              key(:order_end_date).failure("range cannot exceed #{MAX_RANGE_DAYS} days")
+            end
+          end
+
+          private
+
+          def parse_date(value)
+            Date.parse(value.to_s)
+          rescue ArgumentError, TypeError
+            nil
           end
         end
 

--- a/lib/amazon_business_api/shipment_report/operations/search.rb
+++ b/lib/amazon_business_api/shipment_report/operations/search.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'cgi'
+
+module AmazonBusinessApi
+  class ShipmentReport
+    module Operations
+      # GET /reports/2025-06-09/shipmentReports
+      # Returns shipments (with shipmentId) for the given order(s) within a date
+      # range. orderStartDate/orderEndDate are required; the end date cannot be
+      # in the future and the range cannot exceed 366 days.
+      class Search < AmazonBusinessApi::Operation::Search
+        # Resource attribute => query parameter name.
+        QUERY_PARAMS = {
+          order_start_date: 'orderStartDate',
+          order_end_date: 'orderEndDate',
+          order_ids: 'orderIds',
+          region: 'region',
+          shipment_statuses: 'shipmentStatuses',
+          next_page_token: 'nextPageToken'
+        }.freeze
+
+        class Contract < LedgerSync::Ledgers::Contract
+          params do
+            required(:order_start_date).filled(:string)
+            required(:order_end_date).filled(:string)
+            optional(:order_ids).maybe(:string)
+            optional(:region).maybe(:string)
+            optional(:shipment_statuses).maybe(:string)
+            optional(:next_page_token).maybe(:string)
+          end
+        end
+
+        private
+
+        def request_method
+          :get
+        end
+
+        def url
+          "/reports/2025-06-09/shipmentReports?#{query_string}"
+        end
+
+        def query_string
+          QUERY_PARAMS.filter_map do |attr, key|
+            value = resource.public_send(attr)
+            next if value.nil? || value.to_s.empty?
+
+            "#{key}=#{CGI.escape(value.to_s)}"
+          end.join('&')
+        end
+
+        def opts
+          {}
+        end
+      end
+    end
+  end
+end

--- a/lib/amazon_business_api/shipment_report_item/deserializer.rb
+++ b/lib/amazon_business_api/shipment_report_item/deserializer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative '../order_metadata/deserializer'
+require_relative '../shipment_metadata/deserializer'
+require_relative '../shipment_delivery_info/deserializer'
+require_relative '../address/deserializer'
+
+module AmazonBusinessApi
+  class ShipmentReportItem
+    class Deserializer < AmazonBusinessApi::Deserializer
+      references_one :order_metadata, deserializer: OrderMetadata::Deserializer,
+                                      hash_attribute: :orderMetadata
+      references_one :shipment_metadata, deserializer: ShipmentMetadata::Deserializer,
+                                         hash_attribute: :shipmentMetadata
+      references_one :delivery_info, deserializer: ShipmentDeliveryInfo::Deserializer,
+                                     hash_attribute: :deliveryInfo
+      references_one :shipping_address, deserializer: Address::Deserializer,
+                                        hash_attribute: :shippingAddress
+      attribute :purchase_order_number, hash_attribute: :purchaseOrderNumber
+      attribute :shipment_status, hash_attribute: :shipmentStatus
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `AmazonBusinessApi::ShipmentReport` and a `Search` operation for the
**Reporting API v2025-06-09** `getShipmentReports` endpoint:

```
GET /reports/2025-06-09/shipmentReports?orderStartDate=&orderEndDate=&orderIds=&region=
```

## Why

The existing v1 Orders report (`GET /reports/2021-01-08/orders/{orderId}?includeShipments=true`)
returns an order's shipments **without a `shipmentId`** (only `carrierTracking`). The
package-tracking webhook and `getPackageTrackingDetails` are keyed by `shipmentId`, and the
Ordering API `getOrder` is keyed by the buyer-assigned `externalId` (not the Amazon orderId).

`getShipmentReports` fills the gap: it returns a **`shipmentId` per shipment**, keyed by
`orderIds` + a date range — i.e. discoverable from the Amazon order id alone. This lets
consumers resolve a shipment's `shipmentId` (e.g. to persist it and match incoming tracking
webhooks) without needing the `externalId`.

## What's added

- `ShipmentReport` resource — request params double as attributes (mirrors the `Reconciliation`
  pattern) plus the `shipmentsReport` result collection, `nextPageToken`, `size`.
- `ShipmentReport::Operations::Search` — `GET /reports/2025-06-09/shipmentReports`, required
  `orderStartDate`/`orderEndDate`, optional `orderIds`/`region`/`shipmentStatuses`/`nextPageToken`.
- Sub-resources + deserializers: `ShipmentReportItem`, `OrderMetadata`, `ShipmentMetadata`,
  `ShipmentDeliveryInfo`. Shipping address reuses `Address`.

## Notes

- `ShipmentReportItem` reuses `Address` (not `PhysicalAddress`) for the shipping address —
  `PhysicalAddress` has a pre-existing mismatch (camelCase resource attributes vs a snake_case
  deserializer) that raises on deserialize. Worth a separate fix.
- `charges[]` is present in the payload but intentionally omitted (not needed by current
  consumers).
- `order_ids` is modeled as a single string (or comma-separated); batching multiple ids in one
  call is unverified.
- Request params: `orderStartDate`/`orderEndDate` are required, the end date can't be in the
  future, and the range can't exceed 366 days.

## Testing

Validated **end-to-end against the live Amazon Business API** (US) for a real order:
- `Search.perform` → live `GET /reports/2025-06-09/shipmentReports` → `success? == true`
- Response deserialized through the new classes; `shipments_report[].shipment_metadata.shipment_id`
  returned the real shipment ids (`478188194343301`, `478208298891301`) with `shipmentDate`,
  `shipmentStatus`, `deliveryInfo`, etc.
- Rubocop clean.

Sources: [Reporting API v2025-06-09 reference](https://docs.business.amazon.com/docs/reporting-api-v2025-06-09-reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)